### PR TITLE
Fix UserWarning in lab_bandits.ipynb

### DIFF
--- a/lab_bandits.ipynb
+++ b/lab_bandits.ipynb
@@ -684,7 +684,8 @@
     "    fig = plt.figure(figsize=(15, 8))\n",
     "    ax = fig.add_subplot(111)\n",
     "    ax.matshow(agent.get_q_matrix().T)\n",
-    "    ax.set_yticklabels(['', 'left', 'right'])\n",
+    "    ax.set_yticks([0, 1])\n"
+    "    ax.set_yticklabels(['left', 'right'])\n",
     "    plt.xlabel(\"State\")\n",
     "    plt.ylabel(\"Action\")\n",
     "    plt.title(\"Values of state-action pairs\")\n",


### PR DESCRIPTION
In current implementation you get warning:
```
UserWarning: FixedFormatter should only be used together with FixedLocator
```

This pull request fixes it.